### PR TITLE
Additional Comply0 Interoperability Tests

### DIFF
--- a/interop-sharing/IBM/results-tracker-IBM.md
+++ b/interop-sharing/IBM/results-tracker-IBM.md
@@ -18,3 +18,27 @@ https://github.com/oscal-compass/oscal-content/tree/main/examples-direct-mapping
 | mapping| - | -  | - |  |
 
 <br/>
+
+<br/>
+
+# Interoperability Results for Comply0
+
+Web application to manage OSCAL documents. Validated against v0.1.0-preview.5 available at https://app.dev.comply0.com.
+Only JSON files are accepted by the tool. Currently the version can only process JSON catalogs and profiles.  
+To register for an account or request instance of the application please go to: https://www.comply0.com/
+
+
+| File | Tested? | Validates? | Additonal Execution/Processing Results | Notes/Errors |
+|------|---------|------------|------------------------------|-------------|
+| catalogs/hipaa-2.0.0/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
+| catalogs/nist_ai_rm_gen_ai/1.0.0/catalog.json | :heavy_check_mark: | :x:  | N/A | The `$.catalog.metadata.last-modified` attribute value is not a valid [`date-time-with-timezone`](https://pages.nist.gov/metaschema/specification/datatypes/#date-time-with-timezone). |
+| examples-direct-mapping/catalogs/NIST_SP-800-53_rev4/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
+| examples-direct-mapping/catalogs/PCI/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
+| examples-direct-mapping/profiles/Sample_NIST/profile.json | :heavy_check_mark: | :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| examples-direct-mapping/profiles/Sample_PCI/profile.json | :heavy_check_mark: | :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| examples-harmonized-mapping/catalogs/NIST_SP-800-53_rev4/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
+| examples-harmonized-mapping/catalogs/PCI/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
+| examples-harmonized-mapping/profiles/Harmonized_V1.0/profile.json | :heavy_check_mark: | :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| examples-harmonized-mapping/profiles/Harmonized_V1.1/profile.json | :heavy_check_mark: | :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+
+<br/>

--- a/interop-sharing/IBM/results-tracker-IBM.md
+++ b/interop-sharing/IBM/results-tracker-IBM.md
@@ -30,8 +30,8 @@ To register for an account or request instance of the application please go to: 
 
 | File | Tested? | Validates? | Additonal Execution/Processing Results | Notes/Errors |
 |------|---------|------------|------------------------------|-------------|
-| catalogs/hipaa-2.0.0/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
-| catalogs/nist_ai_rm_gen_ai/1.0.0/catalog.json | :heavy_check_mark: | :x:  | N/A | The `$.catalog.metadata.last-modified` attribute value is not a valid [`date-time-with-timezone`](https://pages.nist.gov/metaschema/specification/datatypes/#date-time-with-timezone). |
+| catalogs/hipaa-2.0.0/catalog.json | :heavy_check_mark: | :x: | N/A | The `$.catalog.metadata.last-modified` attribute value is not a valid [`date-time-with-timezone`](https://pages.nist.gov/metaschema/specification/datatypes/#date-time-with-timezone). |
+| catalogs/nist_ai_rm_gen_ai/1.0.0/catalog.json | :heavy_check_mark: | :heavy_check_mark:  | N/A | N/A |
 | examples-direct-mapping/catalogs/NIST_SP-800-53_rev4/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
 | examples-direct-mapping/catalogs/PCI/catalog.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
 | examples-direct-mapping/profiles/Sample_NIST/profile.json | :heavy_check_mark: | :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |

--- a/interop-sharing/easydynamics-comply0/results-tracker.md
+++ b/interop-sharing/easydynamics-comply0/results-tracker.md
@@ -41,6 +41,6 @@ To register for an account or request instance of the application please go to: 
 ### ./scuba
 | File | Tested? | Validates? | Additional Execution/Processing Results | Notes/Errors |
 |------|---------|------------|------------------------------|-------------|
-| SCuBA_oscal_assessment-plan.json | N/A | N/A | N/A | Comply0 doesn't support assessment plans yet. |
+| SCuBA_oscal_assessment-plan.json | :x: | N/A | N/A | N/A |
 
 <br />

--- a/interop-sharing/foundation/results-tracker.md
+++ b/interop-sharing/foundation/results-tracker.md
@@ -91,6 +91,43 @@ Tested using release 2.6.0 of the oscal-cli tool at https://github.com/metaschem
 
 <br/>
 
+# Interoperability Results for Comply0
+
+Web application to manage OSCAL documents. Validated against v0.1.0-preview.5 available at https://app.dev.comply0.com.
+Only JSON files are accepted by the tool. Currently the version can only process JSON catalogs and profiles.  
+To register for an account or request instance of the application please go to: https://www.comply0.com/
+
+### ./edgecases/ultraminimal
+| File | Tested? | Validates? | Additonal Execution/Processing Results | Notes/Errors |
+|------|---------|------------|------------------------------|-------------|
+| ultraMinimalAP.json | :x: | N/A | N/A | N/A |
+| ultraMinimalAR.json | :x: | N/A | N/A | N/A |
+| ultraMinimalCatalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| ultraMinimalComponent.json | :x: | N/A | N/A | N/A |
+| ultraMinimalMapping.json | :x: | N/A: | N/A | N/A |
+| ultraMinimalPOAM.json | :x: | N/A | N/A | N/A |
+| ultraMinimalProfile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| ultraMinimalSSP.json | :x: | N/A | N/A | N/A |
+| ultraMinimalSSP2.json | :x: | N/A | N/A | N/A |
+
+### ./basic
+| File | Tested? | Validates? | Additonal Execution/Processing Results | Notes/Errors |
+|------|---------|------------|------------------------------|-------------|
+| basicAP.json | :x: | N/A | N/A | N/A |
+| basicAR.json | :x: | N/A | N/A | N/A |
+| basicCatalogA.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| basicCatalogB.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| basicComponent.json | :x: | N/A | N/A | N/A |
+| basicMapping.json | :x: | N/A | N/A | N/A |
+| basicPOAM.json | :x: | N/A | N/A | N/A |
+| basicProfile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| basicSSP.json | :x: | N/A | N/A | N/A |
+| basicSSP.json | :x: | N/A | N/A | N/A |
+
+<br/>
+
+<br/>
+
 # Interoperability Results for TOOLNAME
 
 > [!NOTE]

--- a/interop-sharing/nist/results-tracker.md
+++ b/interop-sharing/nist/results-tracker.md
@@ -95,7 +95,48 @@ All files tested using JSON versions.
 
 <br/>
 
-<br/>
+<br />
+
+# Interoperability Results for Comply0
+
+Web application to manage OSCAL documents. Validated against v0.1.0-preview.5 available at https://app.dev.comply0.com.
+Only JSON files are accepted by the tool. Currently the version can only process JSON catalogs and profiles.  
+To register for an account or request instance of the application please go to: https://www.comply0.com/
+
+### ./nist.gov
+| File | Tested? | Validates? | Additional Execution/Processing Results | Notes/Errors |
+|------|---------|------------|------------------------------|-------------|
+| csf/v2.0/json/NIST_CSF_v2.0_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_HIGH-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_LOW-baseline-resolved-profile_catalog.json.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_MODERATE-baseline-resolved-profile_catalog.json.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_HIGH-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_LOW-baseline_profile.json.json | :heavy_check_mark: | :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json.json | :heavy_check_mark: | :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_HIGH-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_LOW-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_MODERATE-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_PRIVACY-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_HIGH-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_LOW-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_PRIVACY_profile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| SP800-171/rev3/json/NIST_SP800-171_rev3_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| SP800-218/ver1/json/NIST_SP800-218_ver1_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+
+
+### ./examples
+| File | Tested? | Validates? | Additional Execution/Processing Results | Notes/Errors |
+|------|---------|------------|------------------------------|-------------|
+| catalog/json/basic-catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
+| profile/json/basic-profile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and `$.profile.imports.href` needs to be fixed up. | N/A |
+| profile/json/basic-profile-resolved.json | :heavy_check_mark: | :heavy_check_mark: | Treated as a catalog. | N/A  |
+
+<br />
+
+<br />
 
 # Interoperability Results for TOOLNAME
 
@@ -133,41 +174,3 @@ Any overall notes or discussion about the content's interoperability here.
 
 <br/>
 
-# Interoperability Results for Comply0
-
-Web application to manage OSCAL documents. Validated against v0.1.0-preview.5 available at https://app.dev.comply0.com.
-Only JSON files are accepted by the tool. Currently the version can only process JSON catalogs and profiles.  
-To register for an account or request instance of the application please go to: https://www.comply0.com/
-
-### ./nist.gov
-| File | Tested? | Validates? | Additional Execution/Processing Results | Notes/Errors |
-|------|---------|------------|------------------------------|-------------|
-| csf/v2.0/json/NIST_CSF_v2.0_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_HIGH-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_LOW-baseline-resolved-profile_catalog.json.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_MODERATE-baseline-resolved-profile_catalog.json.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_HIGH-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_LOW-baseline_profile.json.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev4/v2.0/json/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json.json | :heavy_check_mark: | :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_HIGH-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_LOW-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_MODERATE-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_PRIVACY-baseline-resolved-profile_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_HIGH-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_LOW-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-53/rev5/v2.0/json/NIST_SP-800-53_rev5_PRIVACY_profile.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-171/rev3/json/NIST_SP800-171_rev3_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| SP800-218/ver1/json/NIST_SP800-218_ver1_catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-
-
-### ./examples
-| File | Tested? | Validates? | Additional Execution/Processing Results | Notes/Errors |
-|------|---------|------------|------------------------------|-------------|
-| catalog/json/basic-catalog.json | :heavy_check_mark:| :heavy_check_mark: | N/A | N/A |
-| profile/json/basic-profile.json | :heavy_check_mark:| :heavy_check_mark: | Referenced catalog needs to be uploaded to the web application separately and the `$.profile.imports.href` needs to be fixed up.  | N/A |
-| profile/json/basic-profile-resolved.json | :heavy_check_mark: | :heavy_check_mark: | Treated as a catalog. | N/A  |
-
-<br />


### PR DESCRIPTION
This pull request adds and updates interoperability results for the Comply0 tool across several results tracker markdown files. It introduces new sections documenting which OSCAL files were tested, their validation status, and any notable processing notes or errors.

**Additions and updates for Comply0 interoperability results:**

* Added new interoperability results sections for Comply0 to the following files, detailing which files were tested, validation outcomes, and any required manual steps or errors:
  - `interop-sharing/IBM/results-tracker-IBM.md`
  - `interop-sharing/foundation/results-tracker.md`

**Content organization and cleanup:**

* Moved Comply0 interoperability results in `interop-sharing/nist/results-tracker.md` above template section for better readability.
* Updated the results for EasyDynamics Comply0 in `interop-sharing/easydynamics-comply0/results-tracker.md` to consistently use ":x:" for unsupported files, clarifying the tool's current capabilities.